### PR TITLE
Fix missing language in word list view

### DIFF
--- a/language_app/vocabulary/templates/vocabulary/vocabulary_home.html
+++ b/language_app/vocabulary/templates/vocabulary/vocabulary_home.html
@@ -2,10 +2,10 @@
 
 {% block content %}
     <h1>Witaj w sekcji Vocabulary! dla jezyka: {{ language }}</h1>
-    <a href="{% url "add_word" %}">
+    <a href="{% url 'add_word' language=language %}">
         <button class="button">Dodaj nowe słowo</button>
     </a>
-    <a href="{% url "word_list" %}">
+    <a href="{% url 'word_list' language=language %}">
         <button class="button">Lista słów</button>
     </a>
 {% endblock %}

--- a/language_app/vocabulary/views.py
+++ b/language_app/vocabulary/views.py
@@ -6,11 +6,19 @@ from django.contrib import messages
 from django.urls import resolve
 
 # Create your views here.
-def display_words(request):
-    language = resolve(request.path_info).kwargs.get('language')
-    print("chosen language:", language)
+def display_words(request, language=None):
+    """Display words for the selected language."""
+    if language is None:
+        language = resolve(request.path_info).kwargs.get('language')
     words = Word.objects.filter(language=language)
-    return render(request, 'vocabulary/word_list.html', {'language': language, 'words': words})
+    return render(
+        request,
+        'vocabulary/word_list.html',
+        {
+            'language': language,
+            'words': words,
+        },
+    )
 
 
 def vocabulary_home(request, language):


### PR DESCRIPTION
## Summary
- allow `display_words` view to accept the `language` argument

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68467d3da79c832091066e8501bfe750